### PR TITLE
Automatic Dockerfile Image Updater

### DIFF
--- a/.examples/docker-compose/with-nginx-proxy-self-signed-ssl/mariadb/fpm/proxy/Dockerfile
+++ b/.examples/docker-compose/with-nginx-proxy-self-signed-ssl/mariadb/fpm/proxy/Dockerfile
@@ -1,3 +1,3 @@
-FROM jwilder/nginx-proxy:alpine
+FROM jwilder/nginx-proxy:v0.9.0
 
 COPY uploadsize.conf /etc/nginx/conf.d/uploadsize.conf

--- a/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/apache/proxy/Dockerfile
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/apache/proxy/Dockerfile
@@ -1,3 +1,3 @@
-FROM jwilder/nginx-proxy:alpine
+FROM jwilder/nginx-proxy:v0.9.0
 
 COPY uploadsize.conf /etc/nginx/conf.d/uploadsize.conf

--- a/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/fpm/proxy/Dockerfile
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/fpm/proxy/Dockerfile
@@ -1,3 +1,3 @@
-FROM jwilder/nginx-proxy:alpine
+FROM jwilder/nginx-proxy:v0.9.0
 
 COPY uploadsize.conf /etc/nginx/conf.d/uploadsize.conf

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/apache/proxy/Dockerfile
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/apache/proxy/Dockerfile
@@ -1,3 +1,3 @@
-FROM jwilder/nginx-proxy:alpine
+FROM jwilder/nginx-proxy:v0.9.0
 
 COPY uploadsize.conf /etc/nginx/conf.d/uploadsize.conf

--- a/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/proxy/Dockerfile
+++ b/.examples/docker-compose/with-nginx-proxy/mariadb/fpm/proxy/Dockerfile
@@ -1,3 +1,3 @@
-FROM jwilder/nginx-proxy:alpine
+FROM jwilder/nginx-proxy:v0.9.0
 
 COPY uploadsize.conf /etc/nginx/conf.d/uploadsize.conf

--- a/.examples/docker-compose/with-nginx-proxy/postgres/apache/proxy/Dockerfile
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/apache/proxy/Dockerfile
@@ -1,3 +1,3 @@
-FROM jwilder/nginx-proxy:alpine
+FROM jwilder/nginx-proxy:v0.9.0
 
 COPY uploadsize.conf /etc/nginx/conf.d/uploadsize.conf

--- a/.examples/docker-compose/with-nginx-proxy/postgres/fpm/proxy/Dockerfile
+++ b/.examples/docker-compose/with-nginx-proxy/postgres/fpm/proxy/Dockerfile
@@ -1,3 +1,3 @@
-FROM jwilder/nginx-proxy:alpine
+FROM jwilder/nginx-proxy:v0.9.0
 
 COPY uploadsize.conf /etc/nginx/conf.d/uploadsize.conf


### PR DESCRIPTION
`jwilder/nginx-proxy` changed recently. This pull request ensures you're using the latest version of the image and changes `jwilder/nginx-proxy` to the latest tag: `v0.9.0`

New base image: `jwilder/nginx-proxy:v0.9.0`